### PR TITLE
Malformed attribute crash fix

### DIFF
--- a/ADPluginKafkaApp/src/NDArraySerializer.cpp
+++ b/ADPluginKafkaApp/src/NDArraySerializer.cpp
@@ -58,7 +58,7 @@ void NDArraySerializer::SerializeData(NDArray &pArray,
     size_t bytes;
     NDAttrDataType_t c_type;
     int result = attr_ptr->getValueInfo(&c_type, &bytes);
-    if ((ND_SUCCESS != result) | (0 == bytes))
+    if ((ND_SUCCESS != result) || (0 == bytes))
     {
       continue;
     }

--- a/ADPluginKafkaApp/src/NDArraySerializer.cpp
+++ b/ADPluginKafkaApp/src/NDArraySerializer.cpp
@@ -55,9 +55,6 @@ void NDArraySerializer::SerializeData(NDArray &pArray,
 
   // Iterate over attributes, next(ptr) returns NULL when there are no more
   for (NDAttribute *attr_ptr = pArray.pAttributeList->next(nullptr); attr_ptr != nullptr; attr_ptr = pArray.pAttributeList->next(attr_ptr)) {
-    auto temp_attr_str = builder.CreateString(attr_ptr->getName());
-    auto temp_attr_desc = builder.CreateString(attr_ptr->getDescription());
-    auto temp_attr_src = builder.CreateString(attr_ptr->getSource());
     size_t bytes;
     NDAttrDataType_t c_type;
     int result = attr_ptr->getValueInfo(&c_type, &bytes);
@@ -74,6 +71,11 @@ void NDArraySerializer::SerializeData(NDArray &pArray,
     {
       continue;
     }
+
+    auto temp_attr_str = builder.CreateString(attr_ptr->getName());
+    auto temp_attr_desc = builder.CreateString(attr_ptr->getDescription());
+    auto temp_attr_src = builder.CreateString(attr_ptr->getSource());
+
     auto attrValuePayload = builder.CreateVector(
         reinterpret_cast<unsigned char *>(attrValueBuffer.get()), bytes);
 

--- a/ADPluginKafkaApp/src/NDArraySerializer.cpp
+++ b/ADPluginKafkaApp/src/NDArraySerializer.cpp
@@ -70,17 +70,16 @@ void NDArraySerializer::SerializeData(NDArray &pArray,
     std::unique_ptr<char[]> attrValueBuffer(new char[bytes]);
     int attrValueRes = attr_ptr->getValue(
         c_type, reinterpret_cast<void *>(attrValueBuffer.get()), bytes);
-    if (ND_SUCCESS == attrValueRes) {
-      auto attrValuePayload = builder.CreateVector(
-          reinterpret_cast<unsigned char *>(attrValueBuffer.get()), bytes);
-
-      auto attr = CreateAttribute(builder, temp_attr_str, temp_attr_desc,
-                                  temp_attr_src, attrDType, attrValuePayload);
-      attrVec.push_back(attr);
-    } else {
-      assert(false);
+    if (ND_SUCCESS != attrValueRes)
+    {
+      continue;
     }
+    auto attrValuePayload = builder.CreateVector(
+        reinterpret_cast<unsigned char *>(attrValueBuffer.get()), bytes);
 
+    auto attr = CreateAttribute(builder, temp_attr_str, temp_attr_desc,
+                                temp_attr_src, attrDType, attrValuePayload);
+    attrVec.push_back(attr);
   }
   auto attributes = builder.CreateVector(attrVec);
   auto Timestamp = epicsTimeToNsec(pArray.epicsTS);

--- a/ADPluginKafkaApp/src/NDArraySerializer.cpp
+++ b/ADPluginKafkaApp/src/NDArraySerializer.cpp
@@ -60,7 +60,11 @@ void NDArraySerializer::SerializeData(NDArray &pArray,
     auto temp_attr_src = builder.CreateString(attr_ptr->getSource());
     size_t bytes;
     NDAttrDataType_t c_type;
-    attr_ptr->getValueInfo(&c_type, &bytes);
+    int result = attr_ptr->getValueInfo(&c_type, &bytes);
+    if ((ND_SUCCESS != result) | (0 == bytes))
+    {
+      continue;
+    }
     auto attrDType = GetFB_DType(c_type);
 
     std::unique_ptr<char[]> attrValueBuffer(new char[bytes]);

--- a/ADPluginKafkaApp/src/NDArraySerializer.cpp
+++ b/ADPluginKafkaApp/src/NDArraySerializer.cpp
@@ -53,11 +53,8 @@ void NDArraySerializer::SerializeData(NDArray &pArray,
   // Get all attributes of this data package
   std::vector<flatbuffers::Offset<Attribute>> attrVec;
 
-  // When passing NULL, get first element
-  NDAttribute *attr_ptr = pArray.pAttributeList->next(nullptr);
-
-  // Itterate over attributes, next(ptr) returns NULL when there are no more
-  while (attr_ptr != nullptr) {
+  // Iterate over attributes, next(ptr) returns NULL when there are no more
+  for (NDAttribute *attr_ptr = pArray.pAttributeList->next(nullptr); attr_ptr != nullptr; attr_ptr = pArray.pAttributeList->next(attr_ptr)) {
     auto temp_attr_str = builder.CreateString(attr_ptr->getName());
     auto temp_attr_desc = builder.CreateString(attr_ptr->getDescription());
     auto temp_attr_src = builder.CreateString(attr_ptr->getSource());
@@ -80,7 +77,6 @@ void NDArraySerializer::SerializeData(NDArray &pArray,
       assert(false);
     }
 
-    attr_ptr = pArray.pAttributeList->next(attr_ptr);
   }
   auto attributes = builder.CreateVector(attrVec);
   auto Timestamp = epicsTimeToNsec(pArray.epicsTS);

--- a/ADPluginKafkaApp/src/NDArraySerializer.cpp
+++ b/ADPluginKafkaApp/src/NDArraySerializer.cpp
@@ -58,7 +58,7 @@ void NDArraySerializer::SerializeData(NDArray &pArray,
     size_t bytes;
     NDAttrDataType_t c_type;
     int result = attr_ptr->getValueInfo(&c_type, &bytes);
-    if ((ND_SUCCESS != result) || (0 == bytes))
+    if ((ND_SUCCESS != result) || (NDAttrUndefined == c_type))
     {
       continue;
     }


### PR DESCRIPTION
Fixes #2

We now skip any attribute with an invalid datatype, and also skip instead of asserting if the attribute value doesn't exist. Making this work nicely entailed changing the while loop to a for loop (would be nice if we could use range-based for, but ADCore says no). 

I also noticed the skipped attribute's name was still showing up in the message payload if I watched the topic using kafkacat, so I did some reordering to avoid that orphan data ending up in the buffer.

I've tested this locally, and I'm able to pull messages with skipped attributes out of kafka and decode them using the ESS streaming-data-types python package.