### PR TITLE
Ensure asyn callbacks happen so I/O Intr works

### DIFF
--- a/ADPluginKafkaApp/src/ParameterHandler.cpp
+++ b/ADPluginKafkaApp/src/ParameterHandler.cpp
@@ -62,4 +62,5 @@ void ParameterHandler::updateDbValue(ParameterBase *ParamPtr) {
        }},
   };
   CallMap.at(typeid(*ParamPtr).hash_code())();
+  Driver->callParamCallbacks();
 }


### PR DESCRIPTION
I/O Intr scanning (which is used in the provided DB file) relies on asyn parameter callbacks being called. This is done by calling callParamCallbacks() after set*Param() (see e.g. https://epics.anl.gov/tech-talk/2013/msg00473.php), but it wasn't being done in ParameterHandler.cpp.

This results in the Kafka connection status updating promptly, instead of at weird times.